### PR TITLE
process commandline list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-# Makefile for minishell, updated 2021年 6月 3日 木曜日 11時44分21秒 JST
+# Makefile for minishell, updated 2021年 6月10日 木曜日 17時55分15秒 JST
 
-SRCNAME	:= debug.c get_line.c lex_line.c minishell.c utils.c
+SRCNAME	:= debug.c get_line.c lex_line.c minishell.c process_commandline.c utils.c
 
 # DO NOT ADD OR MODIFY ANY LINES ABOVE THIS -- run 'make source' to add files
 
@@ -13,7 +13,7 @@ NAME	:= minishell
 LIBFTDIR	:= ./libft
 LIBFTNAME 	:= libft.a
 LIBFT		:= $(LIBFTDIR)/$(LIBFTNAME)
-LIBFTTARGET	:= bonus
+LIBFTTARGET	:= all
 
 CC		:= gcc
 CFLAGS	:= -Wall -Wextra -Werror
@@ -24,10 +24,10 @@ all		:	$(NAME)
 .c.o	:
 			$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $(<:.c=.o)
 
-$(NAME)	:	$(LIBFTNAME) $(OBJS)
+$(NAME)	:	$(LIBFT) $(OBJS)
 			$(CC) $(CFLAGS) $(INCLUDE) $(OBJS) $(LIBFT) -o $(NAME)
 
-$(LIBFTNAME):
+$(LIBFT):
 			make $(LIBFTTARGET) -C $(LIBFTDIR)
 
 clean	:
@@ -53,4 +53,4 @@ source:
 	@sed -i "" -r -e "s/(^# Makefile .* updated).*/\1 `date`/" Makefile
 	@sed -i "" -r -e "s/(^SRCNAME\t:=).*/\1 `ls -1 srcs | grep .c | xargs`/" Makefile
 
-.PHONY:	all clean fclean re debug address source $(LIBFTNAME)
+.PHONY:	all clean fclean re debug address source

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/28 09:39:27 by mkamei            #+#    #+#             */
-/*   Updated: 2021/06/04 11:43:34 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/06/10 17:53:57 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,13 +16,13 @@
 # include "../libft/libft.h"
 # include <stdio.h>
 
-# define ERR_NUM 20
-# define ERR_MSG_MAX_LEN 50
+# define BUFFER_SIZE 10
 # define SUCCESS 0
 # define ERR_MALLOC 1
 # define ERR_READ 2
 # define ERR_MULTILINE 3
-# define BUFFER_SIZE 10
+# define ERR_SEMICOLON 4
+# define ERR_D_SEMICOLON 5
 
 typedef enum e_token_type{
 	SEMICOLON	= ';',
@@ -40,6 +40,7 @@ typedef struct s_token
 
 int		get_line(char **line);
 int		lex_line(char *line, t_token **tokens, int *token_num);
+int		process_commandline(t_token *tokens, int start, int end);
 void	free_double_pointer(char **strs);
 void	free_tokens(t_token *tokens);
 int		free_and_return(void *p, int status);

--- a/libft/Makefile
+++ b/libft/Makefile
@@ -32,9 +32,8 @@ SRCNAME	=	ft_strlen.c \
 			ft_putchar_fd.c \
 			ft_putstr_fd.c \
 			ft_putendl_fd.c \
-			ft_putnbr_fd.c
-
-B_NAME	=	ft_lstnew.c \
+			ft_putnbr_fd.c \
+			ft_lstnew.c \
 			ft_lstadd_front.c \
 			ft_lstsize.c \
 			ft_lstlast.c \
@@ -45,9 +44,7 @@ B_NAME	=	ft_lstnew.c \
 			ft_lstmap.c
 
 SRCS	= $(addprefix $(SRCDIR), $(SRCNAME))
-B_SRCS	= $(addprefix $(SRCDIR), $(B_NAME))
 OBJS	= $(SRCS:.c=.o)
-B_OBJS	= $(B_SRCS:.c=.o)
 INCLUDE	= -I./
 NAME	= libft.a
 CC		= gcc
@@ -64,21 +61,18 @@ all		:	$(NAME)
 $(NAME)	:	$(OBJS)
 			$(AR) $(ARFLAGS) $(NAME) $(OBJS)
 
-bonus	:	$(OBJS) $(B_OBJS)
-			$(AR) $(ARFLAGS) $(NAME) $(OBJS) $(B_OBJS)
-
 clean	:
 			$(RM) $(OBJS) $(B_OBJS)
 
 fclean	:	clean
 			$(RM) $(NAME)
 
-re		: fclean all
+re		: 	fclean all
 
-debug	: CFLAGS += -g
-debug	: fclean bonus
+debug	: 	CFLAGS += -g
+debug	: 	re
 
-address	: CFLAGS += -g -fsanitize=address
-address	: fclean bonus
+address	: 	CFLAGS += -g -fsanitize=address
+address	: 	re
 
-.PHONY	: all clean fclean re bonus debug address
+.PHONY	: all clean fclean re debug address

--- a/srcs/get_line.c
+++ b/srcs/get_line.c
@@ -6,46 +6,34 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/31 14:19:21 by mkamei            #+#    #+#             */
-/*   Updated: 2021/06/02 14:02:45 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/06/10 19:30:34 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static int	calloc_buf_and_line(char **buf, char **line)
-{
-	*buf = ft_calloc(BUFFER_SIZE + 1, sizeof(char));
-	if (*buf == NULL)
-		return (ERR_MALLOC);
-	*line = ft_calloc(1, sizeof(char));
-	if (*line == NULL)
-		return (free_and_return(*buf, ERR_MALLOC));
-	return (SUCCESS);
-}
-
 int	get_line(char **line)
 {
-	char	*buf;
+	char	buf[BUFFER_SIZE + 1];
 	char	*tmp;
 	int		readsize;
 
-	if (calloc_buf_and_line(&buf, line) == ERR_MALLOC)
+	*line = ft_strdup("");
+	if (*line == NULL)
 		return (ERR_MALLOC);
+	buf[0] = '\0';
 	readsize = 1;
 	while (buf[readsize - 1] != '\n')
 	{
 		readsize = read(0, buf, BUFFER_SIZE);
 		if (readsize == -1)
-		{
-			free(*line);
-			return (free_and_return(buf, ERR_READ));
-		}
+			return (free_and_return(*line, ERR_READ));
 		buf[readsize] = '\0';
 		tmp = ft_strjoin(*line, buf);
 		free(*line);
 		*line = tmp;
 		if (tmp == NULL)
-			return (free_and_return(buf, ERR_MALLOC));
+			return (ERR_MALLOC);
 	}
-	return (free_and_return(buf, SUCCESS));
+	return (SUCCESS);
 }

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -6,19 +6,24 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/28 15:30:07 by mkamei            #+#    #+#             */
-/*   Updated: 2021/06/03 12:03:49 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/06/10 18:07:03 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static void	set_err_msgs(char err_msgs[ERR_NUM][ERR_MSG_MAX_LEN])
+static void	write_err_msg(int err_num)
 {
-	ft_strlcpy(err_msgs[ERR_MULTILINE],
-		"Not supported multiline commands\n", 34);
+	const char	err_msgs[6][50] = {"", "", "",
+		"Not supported multiline commands",
+		"syntax error near unexpected token `;'",
+		"syntax error near unexpected token `;;'"};
+
+	printf("minishell: ");
+	printf("%s\n", err_msgs[err_num]);
 }
 
-static int	loop_minishell(char err_msgs[ERR_NUM][ERR_MSG_MAX_LEN])
+static int	loop_minishell(void)
 {
 	char	*line;
 	t_token	*tokens;
@@ -35,26 +40,26 @@ static int	loop_minishell(char err_msgs[ERR_NUM][ERR_MSG_MAX_LEN])
 		free(line);
 		if (status == ERR_MALLOC)
 			exit(1);
-		else if (status == ERR_MULTILINE)
+		else if (status == ERR_MULTILINE || token_num == 0)
 		{
-			printf("%s", err_msgs[ERR_MULTILINE]);
+			if (status == ERR_MULTILINE)
+				write_err_msg(ERR_MULTILINE);
+			else
+				free_tokens(tokens);
 			continue ;
 		}
 		print_tokens(tokens);
-		//status = process_commandline(tokens, 0, token_num - 1);
+		status = process_commandline(tokens, 0, token_num - 1);
 		free_tokens(tokens);
-		// if (status == ERR_MALLOC)
-		// 	exit(1);
-		//else if (status != SUCCESS)
-		// 	printf("%s", err_msgs[status]);
+		if (status == ERR_MALLOC)
+			exit(1);
+		else if (status != SUCCESS)
+			write_err_msg(status);
 	}
 }
 
 int	main(void)
 {
-	char	err_msgs[ERR_NUM][ERR_MSG_MAX_LEN];
-
-	set_err_msgs(err_msgs);
-	loop_minishell(err_msgs);
+	loop_minishell();
 	return (0);
 }

--- a/srcs/process_commandline.c
+++ b/srcs/process_commandline.c
@@ -1,0 +1,56 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   process_commandline.c                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/06/10 17:04:53 by mkamei            #+#    #+#             */
+/*   Updated: 2021/06/10 18:00:38 by mkamei           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static int	process_list(t_token *tokens, int start, int end)
+{
+	int		i;
+	int		status;
+
+	i = end;
+	while (i >= 0)
+	{
+		if (tokens[i].type == SEMICOLON)
+			break ;
+		i--;
+	}
+	if (i < 0)
+	{
+		// return (process_pipeline(tokens, start, end));
+		return (SUCCESS);
+	}
+	else
+	{
+		if (i == end)
+			return (ERR_D_SEMICOLON);
+		if (i - 1 < 0)
+			return (ERR_SEMICOLON);
+		status = process_list(tokens, start, i - 1);
+		if (status != SUCCESS)
+			return (status);
+		// return (process_pipeline(tokens, i + 1, end));
+		return (SUCCESS);
+	}
+}
+
+int	process_commandline(t_token *tokens, int start, int end)
+{
+	if (tokens[end].type != SEMICOLON)
+		return (process_list(tokens, start, end));
+	else
+	{
+		if (end - 1 < 0)
+			return (ERR_SEMICOLON);
+		return (process_list(tokens, start, end - 1));
+	}
+}


### PR DESCRIPTION
・libftのMakefileをターゲットbonusを削除して、ターゲットallでbonusまで含めて、ライブラリを作成するようにした。
　make bonusだとrelinkするため。
・Makefileのターゲット$(LIBFTNAME)を$(LIBFT)に変更。$(LIBFTNAME)だとrelinkするため。
・set_err_msgs関数をwrite_msgs関数に変更。err_msgs変数を用意する必要がなくなるため。
・get_line 関数のbuf は固定長なので、mallocしなくてよい。
・token_numが０の場合、つまり入力がスペースや改行のみの場合は、tokensをfreeして、continueするようにした。
・process_commandline, process_list を作成。
   「 ; 」に関する構文エラーは全てキャッチできるようになったはず。。

@keguchi-42 
process_listもまとめてやっちゃいました。
お時間あるときでいいので、レビューお願いします。