### PR TITLE
Fix builtins

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/28 09:39:27 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/17 16:30:46 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/18 17:36:34 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,8 +49,7 @@ typedef enum e_status
 	E_NOCOMMAND			= 9,
 	E_AMBIGUOUS			= 10,
 	E_OPEN				= 11,
-	E_GETCWD			= 12,
-	E_CHDIR				= 13
+	E_GETCWD			= 12
 }			t_status;
 
 typedef enum e_place
@@ -134,7 +133,6 @@ t_list			*get_target_list(t_list *any_list, char *var, int var_name_len);
 t_status		add_new_var(t_list **any_list, char *var);
 
 // utils
-int				redisplay_prompt(void);
 char			*strjoin_with_null_support(char *s1, char *s2);
 t_bool			is_redirect_token(t_token token);
 t_status		strjoin_to_cmd_str(t_token *tokens,
@@ -151,9 +149,9 @@ t_bool			check_valid_identifier(char *var, int var_name_len);
 void			write_err(char *word,
 					t_status status, t_bool is_errno, t_place place);
 t_exit_status	get_exit_status_with_errout(
-					char *word, t_status status, t_place place);
-void			set_exit_status_with_errout(char *word,
-					t_status status, t_place place, t_list *vars_list[3]);
+					char *err_word, t_status status, t_place place);
+t_status		set_exit_status_with_errout(
+					char *err_word, t_status status, t_list *vars_list[3]);
 void			free_double_pointer(void **p);
 void			free_tokens(t_token *tokens);
 t_status		free_and_return(void *p, t_status status);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/28 09:39:27 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/17 16:01:15 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/17 16:30:46 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -136,17 +136,17 @@ t_status		add_new_var(t_list **any_list, char *var);
 // utils
 int				redisplay_prompt(void);
 char			*strjoin_with_null_support(char *s1, char *s2);
-char			*create_full_path(char *path, char *last_file);
-t_status		search_match_path_from_path_var(
-					char *last_file, char *path_value,
-					t_file_check_func check_func, char **matched_path);
 t_bool			is_redirect_token(t_token token);
 t_status		strjoin_to_cmd_str(t_token *tokens,
 					int word_index, char **cmd_str, t_list *vars_list[3]);
 t_status		split_cmd_str(char *cmd_str, char ***command);
 t_status		search_command_path(
 					char *cmd_name, t_list *vars_list[3], char **cmd_path);
-t_status		add_pid_list(t_list **pid_list, pid_t pid);
+t_status		add_to_pid_list(t_list **pid_list, pid_t pid);
+char			*create_full_path(char *path, char *last_file);
+t_status		search_match_path_from_path_var(
+					char *last_file, char *path_value,
+					t_file_check_func check_func, char **matched_path);
 t_bool			check_valid_identifier(char *var, int var_name_len);
 void			write_err(char *word,
 					t_status status, t_bool is_errno, t_place place);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/28 09:39:27 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/11 18:57:29 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/17 16:01:15 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -140,7 +140,7 @@ char			*create_full_path(char *path, char *last_file);
 t_status		search_match_path_from_path_var(
 					char *last_file, char *path_value,
 					t_file_check_func check_func, char **matched_path);
-t_bool			is_redirect_token(t_token_type type);
+t_bool			is_redirect_token(t_token token);
 t_status		strjoin_to_cmd_str(t_token *tokens,
 					int word_index, char **cmd_str, t_list *vars_list[3]);
 t_status		split_cmd_str(char *cmd_str, char ***command);
@@ -158,7 +158,7 @@ void			free_double_pointer(void **p);
 void			free_tokens(t_token *tokens);
 t_status		free_and_return(void *p, t_status status);
 void			free_and_fill_null(char **p);
-void			clear_vars_list(t_list *vars_list[3]);
+void			clear_shell_data(t_data *d);
 
 // debug
 void			print_line_and_word_start_array(char *line, int *word_start);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/28 09:39:27 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/18 17:36:34 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/19 17:45:18 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,7 +49,8 @@ typedef enum e_status
 	E_NOCOMMAND			= 9,
 	E_AMBIGUOUS			= 10,
 	E_OPEN				= 11,
-	E_GETCWD			= 12
+	E_GETCWD			= 12,
+	E_SIG_INTERRUPT		= 13
 }			t_status;
 
 typedef enum e_place
@@ -106,7 +107,8 @@ t_status		process_pipeline(
 t_status		process_command(t_data *d, t_token *tokens, int start, int end);
 t_status		process_redirect(t_token *tokens,
 					int i, t_list **save_fd, t_list *vars_list[3]);
-t_status		expand_word_token(char **word, t_list *vars_list[3]);
+t_status		expand_word_token(char *word, t_list *vars_list[3],
+					t_bool is_document, char **expanded_str);
 
 // builtins
 t_exit_status	mini_echo(t_data *d, char **argv);
@@ -155,7 +157,6 @@ t_status		set_exit_status_with_errout(
 void			free_double_pointer(void **p);
 void			free_tokens(t_token *tokens);
 t_status		free_and_return(void *p, t_status status);
-void			free_and_fill_null(char **p);
 void			clear_shell_data(t_data *d);
 
 // debug

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/28 09:39:27 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/19 17:45:18 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/22 10:58:09 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -157,6 +157,7 @@ t_status		set_exit_status_with_errout(
 void			free_double_pointer(void **p);
 void			free_tokens(t_token *tokens);
 t_status		free_and_return(void *p, t_status status);
+void			safe_free(void **p);
 void			clear_shell_data(t_data *d);
 
 // debug

--- a/srcs/builtins/mini_cd.c
+++ b/srcs/builtins/mini_cd.c
@@ -6,11 +6,64 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/07 20:10:11 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/10 15:51:18 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/16 12:02:54 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+char	*create_full_path(char *path, char *last_file)
+{
+	int		path_len;
+	char	*full_path;
+	char	*tmp;
+
+	if (path == NULL)
+		return (ft_strdup(last_file));
+	else if (last_file == NULL)
+		return (ft_strdup(path));
+	path_len = ft_strlen(path);
+	if (path[path_len - 1] == '/')
+		return (ft_strjoin(path, last_file));
+	full_path = ft_strjoin(path, "/");
+	if (full_path == NULL)
+		return (NULL);
+	tmp = full_path;
+	full_path = ft_strjoin(tmp, last_file);
+	free(tmp);
+	if (full_path == NULL)
+		return (NULL);
+	return (full_path);
+}
+
+t_status	search_match_path_from_path_var(char *last_file
+	, char *path_value, t_file_check_func check_func, char **matched_path)
+{
+	char	**paths;
+	char	*full_path;
+	int		i;
+
+	paths = ft_split(path_value, ':');
+	if (paths == NULL)
+		return (E_SYSTEM);
+	i = -1;
+	*matched_path = NULL;
+	while (*matched_path == NULL && paths[++i] != NULL)
+	{
+		full_path = create_full_path(paths[i], last_file);
+		if (full_path == NULL)
+		{
+			free_double_pointer((void **)paths);
+			return (E_SYSTEM);
+		}
+		if (check_func(full_path) == 1)
+			*matched_path = full_path;
+		else
+			free(full_path);
+	}
+	free_double_pointer((void **)paths);
+	return (SUCCESS);
+}
 
 static t_bool	check_directory_exist(char *path)
 {

--- a/srcs/builtins/mini_cd.c
+++ b/srcs/builtins/mini_cd.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/07 20:10:11 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/16 12:02:54 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/18 17:31:50 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -96,11 +96,11 @@ static t_status	change_dir(t_data *d, char **arg, char *var, char *matched_path)
 	else
 		target_dir = *arg;
 	if (chdir(target_dir) == -1)
-		return (get_exit_status_with_errout(target_dir, E_CHDIR, P_CD));
+		return (get_exit_status_with_errout(target_dir, E_SYSTEM, P_CD));
 	if (set_pwd(d, P_CD, target_dir) == E_SYSTEM)
 		return (get_exit_status_with_errout(NULL, E_SYSTEM, P_CD));
 	if ((var && ft_strncmp(var, "OLDPWD", 7) == 0) || matched_path != NULL)
-		ft_putendl_fd(get_var(d->vars_list, "PWD"), 1);
+		ft_putendl_fd(d->pwd, 1);
 	return (0);
 }
 

--- a/srcs/builtins/mini_exit.c
+++ b/srcs/builtins/mini_exit.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/07 20:12:35 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/09 14:01:22 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/16 13:35:51 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,22 +14,23 @@
 
 t_exit_status	mini_exit(t_data *d, char **argv)
 {
-	int		exit_num;
-	int		i;
+	unsigned long long	exit_num;
+	int					i;
 
-	(void)*d;
 	write(2, "exit\n", 5);
 	if (argv[1] == NULL)
-		exit(0);
-	i = 0;
-	if (argv[1][i] == '+' || argv[1][i] == '-')
-		i++;
+		exit(ft_atoi(get_var(d->vars_list, "?")));
+	i = (argv[1][0] == '+' || argv[1][0] == '-');
+	if (argv[1][i] == '\0')
+		exit(get_exit_status_with_errout(argv[1], E_NUM_ARG_REQ, P_EXIT));
 	exit_num = 0;
 	while (argv[1][i] != '\0')
 	{
-		if (ft_isdigit(argv[1][i]) == 0)
-			exit(get_exit_status_with_errout(argv[1], E_NUM_ARG_REQ, P_EXIT));
 		exit_num = exit_num * 10 + argv[1][i] - '0';
+		if (ft_isdigit(argv[1][i]) == 0
+			|| (argv[1][0] == '-' && exit_num > (unsigned long long) -LLONG_MIN)
+			|| (argv[1][0] != '-' && exit_num > (unsigned long long)LLONG_MAX))
+			exit(get_exit_status_with_errout(argv[1], E_NUM_ARG_REQ, P_EXIT));
 		i++;
 	}
 	if (argv[2] != NULL)

--- a/srcs/builtins/mini_export.c
+++ b/srcs/builtins/mini_export.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/07 14:33:48 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/09 14:01:47 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/16 12:00:00 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -107,8 +107,8 @@ t_exit_status	mini_export(t_data *d, char **argv)
 		else
 			var_name_len = equal_pointer - argv[i];
 		if (check_valid_identifier(argv[i], var_name_len) == 0)
-			exit_status = get_exit_status_with_errout(
-					argv[i], E_INVALID_ID, P_EXPORT);
+			exit_status
+				= get_exit_status_with_errout(argv[i], E_INVALID_ID, P_EXPORT);
 		else if (set_var(d->vars_list, argv[i], ENV) == E_SYSTEM)
 			return (get_exit_status_with_errout(NULL, E_SYSTEM, P_EXPORT));
 	}

--- a/srcs/builtins/mini_unset.c
+++ b/srcs/builtins/mini_unset.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/07 14:33:51 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/09 14:02:24 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/16 12:00:15 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,8 +26,8 @@ t_exit_status	mini_unset(t_data *d, char **argv)
 	{
 		var_name_len = ft_strlen(argv[i]);
 		if (check_valid_identifier(argv[i], var_name_len) == 0)
-			exit_status = get_exit_status_with_errout(
-					argv[i], E_INVALID_ID, P_UNSET);
+			exit_status
+				= get_exit_status_with_errout(argv[i], E_INVALID_ID, P_UNSET);
 		else
 			delete_var(d->vars_list, argv[i], SHELL);
 		i++;

--- a/srcs/expand_word.c
+++ b/srcs/expand_word.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/18 11:54:50 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/20 21:32:03 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/22 11:42:39 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,15 +26,15 @@ static t_status	substr_and_strjoin(
 		substr = get_var(vars_list, &substr_start[1]);
 	else
 		substr = substr_start;
-	if (*expanded_str[0] == '\0' && substr == NULL && backup_char == '\0')
+	if ((substr == NULL || substr[0] == '\0')
+		&& *expanded_str[0] == '\0' && backup_char == '\0')
 	{
-		free(*expanded_str);
-		*expanded_str = NULL;
 		substr_start[len] = backup_char;
+		safe_free((void **)expanded_str);
 		return (SUCCESS);
 	}
 	tmp = *expanded_str;
-	*expanded_str = strjoin_with_null_support(tmp, substr);
+	*expanded_str = ft_strjoin(tmp, substr);
 	free(tmp);
 	substr_start[len] = backup_char;
 	if (*expanded_str == NULL)

--- a/srcs/expand_word.c
+++ b/srcs/expand_word.c
@@ -6,124 +6,98 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/18 11:54:50 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/07 21:04:00 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/20 17:25:12 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static char	*strjoin_with_free(char *str, char *sub)
+static t_status	substr_and_strjoin(
+	char *substr_start, int len, t_list *vars_list[3], char **expanded_str)
 {
-	char	*new_str;
+	char		*substr;
+	char		*tmp;
+	const char	backup_char = substr_start[len];
 
-	if (str == NULL)
-		new_str = sub;
+	if (len == 0)
+		return (SUCCESS);
+	substr_start[len] = '\0';
+	if (vars_list != NULL)
+		substr = get_var(vars_list, &substr_start[1]);
 	else
+		substr = substr_start;
+	if (*expanded_str[0] == '\0' && substr == NULL && backup_char == '\0')
 	{
-		new_str = ft_strjoin(str, sub);
-		free(str);
-		free(sub);
-		if (new_str == NULL)
-			return (NULL);
+		free(*expanded_str);
+		*expanded_str = NULL;
+		substr_start[len] = backup_char;
+		return (SUCCESS);
 	}
-	return (new_str);
+	tmp = *expanded_str;
+	*expanded_str = strjoin_with_null_support(tmp, substr);
+	free(tmp);
+	substr_start[len] = backup_char;
+	if (*expanded_str == NULL)
+		return (E_SYSTEM);
+	return (SUCCESS);
 }
 
-static char	*substr_with_expand(
-	char *substr_start, int len, t_str_type type, t_list *vars_list[3])
+static t_bool	judge_special_dollar_char(
+	char *word, int i, t_bool is_document, t_bool is_rec_call)
 {
-	char	*sub;
-	char	*tmp;
+	static t_str_type	type;
 
-	sub = ft_substr(substr_start, 0, len);
-	if (sub == NULL)
-		return (NULL);
-	if (type != S_QUOTE && sub[0] == '$' && sub[1] != '\0')
+	if (i == 0 && is_rec_call == 0)
+		type = RAW;
+	is_rec_call = 1;
+	if (is_document == 1)
+		is_rec_call = 0;
+	else if (type == RAW
+		&& ft_strchr("\'\"", word[i]) && ft_strchr(&word[i + 1], word[i]))
+		type = word[i];
+	else if ((type == '\'' && word[i] == '\'')
+		|| (type == '\"' && word[i] == '\"'))
+		type = RAW;
+	else if (type == RAW && word[i] == '$'
+		&& ft_strchr("\'\"", word[i + 1]) && ft_strchr(&word[i + 2], word[i + 1]))
+		;
+	else
+		is_rec_call = 0;
+	if (is_rec_call == 1)
 	{
-		tmp = get_var(vars_list, &sub[1]);
-		free(sub);
-		if (tmp == NULL)
-			sub = ft_strdup("");
-		else
-			sub = ft_strdup(tmp);
-		if (sub == NULL)
-			return (NULL);
+		ft_strlcpy(&word[i], &word[i + 1], ft_strlen(&word[i + 1]) + 1);
+		return (judge_special_dollar_char(word, i, is_document, is_rec_call));
 	}
-	return (sub);
+	return (word[i] == '$' && type != '\''
+		&& (ft_isalpha(word[i + 1]) || ft_strchr("?_", word[i + 1])));
 }
 
-static t_str_type	judge_str_type(
-	char *word, int i, t_str_type type, int *start)
+t_status	expand_word_token(
+	char *word, t_list *vars_list[3], t_bool is_document, char **expanded_str)
 {
-	static t_str_type	next_type = '\0';
-
-	if (next_type != '\0')
-	{
-		type = next_type;
-		next_type = '\0';
-	}
-	if (type == RAW && word[i] == '\'' && ft_strchr(&word[i + 1], '\''))
-	{
-		type = S_QUOTE;
-		if (i > 0 && word[i - 1] == '$')
-			(*start)++;
-	}
-	else if (type == RAW && word[i] == '\"' && ft_strchr(&word[i + 1], '\"'))
-	{
-		type = D_QUOTE;
-		if (i > 0 && word[i - 1] == '$')
-			(*start)++;
-	}
-	else if ((type == S_QUOTE && word[i] == '\'')
-		|| (type == D_QUOTE && word[i] == '\"'))
-	{
-		next_type = RAW;
-	}
-	return (type);
-}
-
-static t_status	loop_substr_and_strjoin_to_str(
-	char *word, t_list *vars_list[3], int start, char **str)
-{
-	int			i;
-	t_str_type	type;
-	char		*sub;
+	int		i;
+	int		start;
+	int		dollar_index;
 
 	i = -1;
-	type = RAW;
-	while (word[start] != '\0' && (++i || 1))
-	{
-		type = judge_str_type(word, i, type, &start);
-		if ((type == RAW && ft_strchr(":$\0", word[i]) != NULL)
-			|| (type == S_QUOTE && ft_strchr("\'\0", word[i]) != NULL)
-			|| (type == D_QUOTE && ft_strchr("\" :$\0", word[i]) != NULL))
-		{
-			sub = substr_with_expand(&word[start], i - start, type, vars_list);
-			if (sub == NULL)
-				return (E_SYSTEM);
-			*str = strjoin_with_free(*str, sub);
-			if (*str == NULL)
-				return (E_SYSTEM);
-			if (type == RAW && (*str)[0] == '\0')
-				free_and_fill_null(str);
-			start = i + (word[i] == '\"' || word[i] == '\'');
-		}
-	}
-	return (SUCCESS);
-}
-
-t_status	expand_word_token(char **word, t_list *vars_list[3])
-{
-	int			start;
-	char		*str;
-	t_status	status;
-
 	start = 0;
-	str = NULL;
-	status = loop_substr_and_strjoin_to_str(*word, vars_list, start, &str);
-	if (status == E_SYSTEM)
+	*expanded_str = ft_strdup("");
+	if (*expanded_str == NULL)
 		return (E_SYSTEM);
-	free(*word);
-	*word = str;
-	return (SUCCESS);
+	while (word[++i] != '\0')
+	{
+		if (judge_special_dollar_char(word, i, is_document, 0) == 0)
+			continue ;
+		dollar_index = i++;
+		if (word[dollar_index + 1] != '?')
+			while (ft_isalnum(word[i + 1]) || word[i + 1] == '_')
+				i++;
+		if (substr_and_strjoin(&word[start]
+				, dollar_index - start, NULL, expanded_str) == E_SYSTEM
+			|| substr_and_strjoin(&word[dollar_index]
+				, i + 1 - dollar_index, vars_list, expanded_str) == E_SYSTEM)
+			return (E_SYSTEM);
+		start = i + 1;
+	}
+	return (substr_and_strjoin(&word[start], i - start, NULL, expanded_str));
 }

--- a/srcs/expand_word.c
+++ b/srcs/expand_word.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/18 11:54:50 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/20 17:25:12 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/20 21:32:03 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,13 +52,13 @@ static t_bool	judge_special_dollar_char(
 	is_rec_call = 1;
 	if (is_document == 1)
 		is_rec_call = 0;
-	else if (type == RAW
+	else if (type == RAW && word[i] != '\0'
 		&& ft_strchr("\'\"", word[i]) && ft_strchr(&word[i + 1], word[i]))
 		type = word[i];
 	else if ((type == '\'' && word[i] == '\'')
 		|| (type == '\"' && word[i] == '\"'))
 		type = RAW;
-	else if (type == RAW && word[i] == '$'
+	else if (type == RAW && word[i] == '$' && word[i + 1] != '\0'
 		&& ft_strchr("\'\"", word[i + 1]) && ft_strchr(&word[i + 2], word[i + 1]))
 		;
 	else
@@ -68,7 +68,7 @@ static t_bool	judge_special_dollar_char(
 		ft_strlcpy(&word[i], &word[i + 1], ft_strlen(&word[i + 1]) + 1);
 		return (judge_special_dollar_char(word, i, is_document, is_rec_call));
 	}
-	return (word[i] == '$' && type != '\''
+	return (word[i] == '$' && type != '\'' && word[i + 1] != '\0'
 		&& (ft_isalpha(word[i + 1]) || ft_strchr("?_", word[i + 1])));
 }
 

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/28 15:30:07 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/10 15:05:55 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/17 16:11:26 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,19 +23,9 @@ int	redisplay_prompt(void)
 	{
 		g_received_signal = 0;
 		printf("\033[%dC\033[K", (int)ft_strlen(rl_prompt) + rl_end);
-		if (ft_strncmp(rl_prompt, "> ", 3) == 0)
-		{
-			rl_redisplay();
-			rl_replace_line("\3", 1);
-			rl_done = 1;
-		}
-		else
-		{
-			printf("\n");
-			rl_replace_line("", 1);
-			rl_on_new_line();
-			rl_redisplay();
-		}
+		rl_redisplay();
+		rl_replace_line("\3", 1);
+		rl_done = 1;
 	}
 	else if (g_received_signal == SIGQUIT)
 	{
@@ -46,15 +36,26 @@ int	redisplay_prompt(void)
 	return (0);
 }
 
-static void	exit_by_eof(t_data *d)
+static t_bool	check_interrupt(t_data *d, char *line)
 {
-	free(d->pwd);
-	ft_lstclear(&d->pid_list, free);
-	clear_vars_list(d->vars_list);
-	printf("\033[1A\033[11C");
-	rl_redisplay();
-	write(2, "exit\n", 5);
-	exit(0);
+	t_exit_status	exit_status;
+
+	if (line == NULL)
+	{
+		exit_status = ft_atoi(get_var(d->vars_list, "?"));
+		clear_shell_data(d);
+		printf("\033[1A\033[11C");
+		rl_redisplay();
+		write(2, "exit\n", 5);
+		exit(exit_status);
+	}
+	else if (line[0] == '\3')
+	{
+		free(line);
+		set_exit_status(d->vars_list[SPECIAL], 1);
+		return (1);
+	}
+	return (0);
 }
 
 static void	loop_minishell(t_data *d)
@@ -69,20 +70,19 @@ static void	loop_minishell(t_data *d)
 	{
 		g_received_signal = 0;
 		line = readline("minishell$ ");
-		if (line == NULL)
-			exit_by_eof(d);
+		if (check_interrupt(d, line) == 1)
+			continue ;
 		if (line[0] != '\0')
 			add_history(line);
 		status = lex_line(line, &tokens, &token_num);
 		free(line);
-		if (status != SUCCESS)
+		if (status == E_SYSTEM)
 			break ;
-		status = start_process(d, tokens, 0, token_num - 1);
+		if (token_num != 0)
+			status = start_process(d, tokens, 0, token_num - 1);
 		free_tokens(tokens);
 	}
-	free(d->pwd);
-	ft_lstclear(&d->pid_list, free);
-	clear_vars_list(d->vars_list);
+	clear_shell_data(d);
 	exit(get_exit_status_with_errout(NULL, status, P_SHELL));
 }
 
@@ -95,7 +95,7 @@ int	main(int argc, char **argv, char **envp)
 	if (signal(SIGINT, handler) == SIG_ERR
 		|| signal(SIGQUIT, handler) == SIG_ERR)
 		exit(get_exit_status_with_errout(NULL, E_SYSTEM, P_SHELL));
-	rl_signal_event_hook = &redisplay_prompt;
+	rl_event_hook = &redisplay_prompt;
 	d.pwd = NULL;
 	d.pid_list = NULL;
 	d.vars_list[SHELL] = NULL;
@@ -108,7 +108,7 @@ int	main(int argc, char **argv, char **envp)
 		|| countup_shlvl_env(&d.vars_list[ENV]) == E_SYSTEM
 		|| set_pwd(&d, P_SHELL, NULL) == E_SYSTEM)
 	{
-		clear_vars_list(d.vars_list);
+		clear_shell_data(&d);
 		exit(get_exit_status_with_errout(NULL, E_SYSTEM, P_SHELL));
 	}
 	loop_minishell(&d);

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/28 15:30:07 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/17 16:11:26 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/18 17:36:01 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,21 +17,13 @@ static void	handler(int signum)
 	g_received_signal = signum;
 }
 
-int	redisplay_prompt(void)
+static int	interrupt_by_signal(void)
 {
 	if (g_received_signal == SIGINT)
 	{
 		g_received_signal = 0;
-		printf("\033[%dC\033[K", (int)ft_strlen(rl_prompt) + rl_end);
-		rl_redisplay();
 		rl_replace_line("\3", 1);
 		rl_done = 1;
-	}
-	else if (g_received_signal == SIGQUIT)
-	{
-		g_received_signal = 0;
-		printf("\033[%dC\033[K", (int)ft_strlen(rl_prompt) + rl_end);
-		rl_redisplay();
 	}
 	return (0);
 }
@@ -44,8 +36,6 @@ static t_bool	check_interrupt(t_data *d, char *line)
 	{
 		exit_status = ft_atoi(get_var(d->vars_list, "?"));
 		clear_shell_data(d);
-		printf("\033[1A\033[11C");
-		rl_redisplay();
 		write(2, "exit\n", 5);
 		exit(exit_status);
 	}
@@ -93,9 +83,9 @@ int	main(int argc, char **argv, char **envp)
 	(void)argc;
 	(void)**argv;
 	if (signal(SIGINT, handler) == SIG_ERR
-		|| signal(SIGQUIT, handler) == SIG_ERR)
+		|| signal(SIGQUIT, SIG_IGN) == SIG_ERR)
 		exit(get_exit_status_with_errout(NULL, E_SYSTEM, P_SHELL));
-	rl_event_hook = &redisplay_prompt;
+	rl_event_hook = &interrupt_by_signal;
 	d.pwd = NULL;
 	d.pid_list = NULL;
 	d.vars_list[SHELL] = NULL;

--- a/srcs/process_command.c
+++ b/srcs/process_command.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/19 09:24:35 by keguchi           #+#    #+#             */
-/*   Updated: 2021/08/10 15:29:52 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/17 16:30:06 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -77,7 +77,7 @@ static t_status	exec_command(t_data *d, char **command, t_bool is_pipe)
 		else
 			exec_external_command(command, d->vars_list);
 	}
-	status = add_pid_list(&d->pid_list, pid);
+	status = add_to_pid_list(&d->pid_list, pid);
 	if (status == E_SYSTEM)
 		return (E_SYSTEM);
 	return (SUCCESS);

--- a/srcs/process_command.c
+++ b/srcs/process_command.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/19 09:24:35 by keguchi           #+#    #+#             */
-/*   Updated: 2021/08/17 16:30:06 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/17 16:57:50 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -121,13 +121,13 @@ t_status	process_command(t_data *d, t_token *tokens, int start, int end)
 	cmd_str = NULL;
 	command = NULL;
 	status = SUCCESS;
-	while (status == SUCCESS && start <= end)
+	start -= 1;
+	while (status == SUCCESS && ++start <= end)
 	{
 		if (tokens[start].type == WORD)
 			status = strjoin_to_cmd_str(tokens, start, &cmd_str, d->vars_list);
 		else
 			status = process_redirect(tokens, start++, &save_fd, d->vars_list);
-		start++;
 	}
 	if (status == SUCCESS)
 		status = split_cmd_str(cmd_str, &command);

--- a/srcs/process_command.c
+++ b/srcs/process_command.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/19 09:24:35 by keguchi           #+#    #+#             */
-/*   Updated: 2021/08/18 17:24:18 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/20 17:05:07 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -127,7 +127,8 @@ t_status	process_command(t_data *d, t_token *tokens, int start, int end)
 		if (tokens[start].type == WORD)
 			status = strjoin_to_cmd_str(tokens, start, &cmd_str, d->vars_list);
 		else
-			status = process_redirect(tokens, start++, &save_fd, d->vars_list);
+			start++;
+		// 	status = process_redirect(tokens, start++, &save_fd, d->vars_list);
 	}
 	if (status == SUCCESS)
 		status = split_cmd_str(cmd_str, &command);

--- a/srcs/process_command.c
+++ b/srcs/process_command.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/19 09:24:35 by keguchi           #+#    #+#             */
-/*   Updated: 2021/08/17 16:57:50 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/18 17:24:18 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,7 +91,7 @@ static t_status	edit_status_with_restore_fd(
 	int				backup_fd;
 
 	if (status == E_OPEN || status == E_AMBIGUOUS)
-		set_exit_status_with_errout(err_word, status, P_SHELL, d->vars_list);
+		set_exit_status_with_errout(err_word, status, d->vars_list);
 	if (status == SUCCESS || status == E_OPEN || status == E_AMBIGUOUS)
 	{
 		list = save_fd;

--- a/srcs/process_command_utils.c
+++ b/srcs/process_command_utils.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/08/01 13:09:34 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/17 16:29:54 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/20 17:26:52 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,27 +15,26 @@
 t_status	strjoin_to_cmd_str(
 	t_token *tokens, int word_index, char **cmd_str, t_list *vars_list[3])
 {
-	char		*tmp;
+	char	*tmp;
+	char	*expanded_str;
 
-	if (expand_word_token(&tokens[word_index].str, vars_list) == E_SYSTEM)
+	if (expand_word_token(tokens[word_index].str, vars_list, 0, &expanded_str)
+		 == E_SYSTEM)
 		return (E_SYSTEM);
-	if (tokens[word_index].str == NULL)
+	if (expanded_str == NULL)
 		return (SUCCESS);
-	else if ((tokens[word_index].str)[0] == '\0')
-	{
-		free(tokens[word_index].str);
-		tokens[word_index].str = ft_strdup("\21");
-		if (tokens[word_index].str == NULL)
-			return (E_SYSTEM);
-	}
 	tmp = *cmd_str;
 	*cmd_str = strjoin_with_null_support(tmp, " ");
 	free(tmp);
 	if (*cmd_str == NULL)
 		return (E_SYSTEM);
 	tmp = *cmd_str;
-	*cmd_str = strjoin_with_null_support(tmp, tokens[word_index].str);
+	if (expanded_str[0] == '\0')
+		*cmd_str = strjoin_with_null_support(tmp, "\21");
+	else
+		*cmd_str = strjoin_with_null_support(tmp, expanded_str);
 	free(tmp);
+	free(expanded_str);
 	if (*cmd_str == NULL)
 		return (E_SYSTEM);
 	return (SUCCESS);

--- a/srcs/process_command_utils.c
+++ b/srcs/process_command_utils.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/08/01 13:09:34 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/17 12:16:58 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/17 16:29:54 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -104,7 +104,7 @@ t_status	search_command_path(
 	return (SUCCESS);
 }
 
-t_status	add_pid_list(t_list **pid_list, pid_t pid)
+t_status	add_to_pid_list(t_list **pid_list, pid_t pid)
 {
 	pid_t	*pid_copy;
 	t_list	*new_list;

--- a/srcs/process_command_utils.c
+++ b/srcs/process_command_utils.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/08/01 13:09:34 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/10 15:27:19 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/17 12:16:58 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -106,19 +106,13 @@ t_status	search_command_path(
 
 t_status	add_pid_list(t_list **pid_list, pid_t pid)
 {
-	int		digit_num;
-	int		nbr;
 	pid_t	*pid_copy;
 	t_list	*new_list;
 
-	nbr = pid;
-	digit_num = 0;
-	while (++digit_num && nbr / 10 != 0)
-		nbr = nbr / 10;
-	pid_copy = (pid_t *)malloc(sizeof(pid_t) * digit_num);
+	pid_copy = (pid_t *)malloc(sizeof(pid_t));
 	if (pid_copy == NULL)
 		return (E_SYSTEM);
-	ft_memcpy(pid_copy, &pid, sizeof(pid_t) * digit_num);
+	ft_memcpy(pid_copy, &pid, sizeof(pid_t));
 	new_list = ft_lstnew(pid_copy);
 	if (new_list == NULL)
 	{

--- a/srcs/process_redirect.c
+++ b/srcs/process_redirect.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/19 09:25:38 by keguchi           #+#    #+#             */
-/*   Updated: 2021/08/18 17:39:36 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/20 17:31:32 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -107,8 +107,9 @@ t_status	process_redirect(t_token *tokens, int i,
 		original_token = ft_strdup(tokens[i + 1].str);
 		if (!original_token)
 			return (E_SYSTEM);
-		if (expand_word_token(&tokens[i + 1].str, vars_list) == E_SYSTEM)
-			return (E_SYSTEM);
+		(void)(**vars_list);
+		// if (expand_word_token(&tokens[i + 1].str, vars_list) == E_SYSTEM)
+		// 	return (E_SYSTEM);
 		if (!tokens[i + 1].str)
 		{
 			tokens[i + 1].str = original_token;

--- a/srcs/process_redirect.c
+++ b/srcs/process_redirect.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   process_redirect.c                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: keguchi <keguchi@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/19 09:25:38 by keguchi           #+#    #+#             */
-/*   Updated: 2021/08/05 14:10:53 by keguchi          ###   ########.fr       */
+/*   Updated: 2021/08/18 17:39:36 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,7 +64,7 @@ static t_status	wait_eof_loop(char *eof_word)
 		|| close(pipe_fd[0]) == -1)
 		return (E_SYSTEM);
 	return (SUCCESS);
-}	
+}
 
 static t_status	open_and_redirect_file(t_token *tokens,
 	int file_index, t_list **save_fd)
@@ -85,7 +85,7 @@ static t_status	open_and_redirect_file(t_token *tokens,
 		fd = open(tokens[file_index].str, O_RDWR | O_CREAT | O_APPEND, 0644);
 	else if (tokens[file_index - 1].type == 'L')
 	{
-		rl_event_hook = &redisplay_prompt;
+		// rl_event_hook = &redisplay_prompt;
 		status = wait_eof_loop(tokens[file_index].str);
 		return (status);
 	}

--- a/srcs/start_process.c
+++ b/srcs/start_process.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/08/09 16:54:39 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/17 16:06:55 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/18 17:28:09 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,20 +41,20 @@ static t_status	check_syntax_error(t_token *tokens, char **err_word)
 	return (SUCCESS);
 }
 
-static t_status	wait_child_process(t_list **pid_list, t_list *vars_list[3])
+static t_status	wait_child_process(t_list *pid_list, t_list *vars_list[3])
 {
-	t_list		*current_list;
 	int			status;
 	t_bool		sigint_flag;
 
+	if (pid_list == NULL)
+		return (SUCCESS);
 	sigint_flag = 0;
-	current_list = *pid_list;
-	while (current_list != NULL)
+	while (pid_list != NULL)
 	{
-		if (waitpid(*(pid_t *)current_list->content, &status, 0) == -1)
+		if (waitpid(*(pid_t *)pid_list->content, &status, 0) == -1)
 			return (E_SYSTEM);
 		sigint_flag |= (WIFSIGNALED(status) && WTERMSIG(status) == SIGINT);
-		current_list = current_list->next;
+		pid_list = pid_list->next;
 	}
 	if (WIFEXITED(status))
 		status = WEXITSTATUS(status);
@@ -63,10 +63,10 @@ static t_status	wait_child_process(t_list **pid_list, t_list *vars_list[3])
 	else
 		status = get_exit_status_with_errout(NULL, E_SYSTEM, P_SHELL);
 	set_exit_status(vars_list[SPECIAL], status);
-	write(1, "\n", sigint_flag);
-	write(1, "Quit: 3\n", (status == (SIGQUIT + 128)) * 8);
-	ft_lstclear(pid_list, free);
-	*pid_list = NULL;
+	if (sigint_flag == 1)
+		write(1, "\n", sigint_flag);
+	else if (status == SIGQUIT + 128)
+		write(1, "Quit: 3\n", 8);
 	return (SUCCESS);
 }
 
@@ -77,24 +77,24 @@ t_status	start_process(t_data *d, t_token *tokens, int start, int end)
 	char		*err_word;
 
 	if (check_syntax_error(tokens, &err_word) == E_SYNTAX)
-	{
-		set_exit_status_with_errout(err_word, E_SYNTAX, P_SHELL, d->vars_list);
-		return (SUCCESS);
-	}
+		return (set_exit_status_with_errout(err_word, E_SYNTAX, d->vars_list));
 	// status = heredocument();
 	// if (status == E_SYSTEM)
 	// 	return (E_SYSTEM);
 	// else if (status == E_HEREDOC)
 	// 	return (SUCCESS);
 	backup_read_fd = dup(0);
-	if (backup_read_fd == -1)
+	if (backup_read_fd == -1
+		|| signal(SIGQUIT, SIG_DFL) == SIG_ERR)
 		return (E_SYSTEM);
 	status = process_pipeline(d, tokens, start, end);
 	if (status != SUCCESS)
 		return (status);
-	if (dup2(backup_read_fd, 0) == -1 || close(backup_read_fd) == -1)
+	if (dup2(backup_read_fd, 0) == -1 || close(backup_read_fd) == -1
+		|| signal(SIGQUIT, SIG_IGN) == SIG_ERR)
 		return (E_SYSTEM);
-	if (d->pid_list != NULL)
-		status = wait_child_process(&d->pid_list, d->vars_list);
+	status = wait_child_process(d->pid_list, d->vars_list);
+	ft_lstclear(&d->pid_list, free);
+	d->pid_list = NULL;
 	return (status);
 }

--- a/srcs/start_process.c
+++ b/srcs/start_process.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/08/09 16:54:39 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/11 19:07:51 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/17 16:06:55 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,25 +17,25 @@ static t_status	check_syntax_error(t_token *tokens, char **err_word)
 	int		i;
 
 	i = -1;
+	*err_word = NULL;
 	while (*err_word == NULL && tokens[++i].type != '\0')
 	{
-		if (tokens[i].type == PIPE && (i == 0 || tokens[i - 1].type != WORD))
-			*err_word = "`|'";
-		else if (is_redirect_token(tokens[i].type) == 1
-			&& i != 0 && is_redirect_token(tokens[i - 1].type) == 1)
+		if (is_redirect_token(tokens[i]) && is_redirect_token(tokens[i + 1]))
 		{
-			if (tokens[i].type == GREATER)
+			if (tokens[i + 1].type == GREATER)
 				*err_word = "`>'";
-			else if (tokens[i].type == D_GREATER)
+			if (tokens[i + 1].type == D_GREATER)
 				*err_word = "`>>'";
-			else if (tokens[i].type == LESS)
+			else if (tokens[i + 1].type == LESS)
 				*err_word = "`<'";
-			else if (tokens[i].type == D_LESS)
+			else if (tokens[i + 1].type == D_LESS)
 				*err_word = "`<<'";
 		}
+		else if (tokens[i].type != WORD && tokens[i + 1].type == PIPE)
+			*err_word = "`|'";
+		else if (tokens[i].type != WORD && tokens[i + 1].type == '\0')
+			*err_word = "`newline'";
 	}
-	if (tokens[i].type == '\0' && tokens[i - 1].type != WORD)
-		*err_word = "`newline'";
 	if (*err_word != NULL)
 		return (E_SYNTAX);
 	return (SUCCESS);
@@ -76,16 +76,16 @@ t_status	start_process(t_data *d, t_token *tokens, int start, int end)
 	t_status	status;
 	char		*err_word;
 
-	if (end == -1)
-		return (SUCCESS);
-	err_word = NULL;
 	if (check_syntax_error(tokens, &err_word) == E_SYNTAX)
 	{
 		set_exit_status_with_errout(err_word, E_SYNTAX, P_SHELL, d->vars_list);
 		return (SUCCESS);
 	}
-	// if (heredocument() == E_SYSTEM)
+	// status = heredocument();
+	// if (status == E_SYSTEM)
 	// 	return (E_SYSTEM);
+	// else if (status == E_HEREDOC)
+	// 	return (SUCCESS);
 	backup_read_fd = dup(0);
 	if (backup_read_fd == -1)
 		return (E_SYSTEM);

--- a/srcs/utils/debug.c
+++ b/srcs/utils/debug.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/30 17:55:37 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/20 14:44:11 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/23 17:31:30 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,9 +47,11 @@ void	print_tokens(t_token *tokens, t_list *vars_list[3])
 			if (expand_word_token(tokens[i].str, vars_list, 0, &expanded_str)
 				 == E_SYSTEM)
 				return ;
+			printf("%2d	type:%c, str:%s,\n", i, tokens[i].type, expanded_str);
+			free(expanded_str);
 		}
-		printf("%2d	type:%c, str:%s,\n", i, tokens[i].type, expanded_str);
-		free(expanded_str);
+		else
+			printf("%2d	type:%c, str:%s,\n", i, tokens[i].type, tokens[i].str);
 		i++;
 	}
 }

--- a/srcs/utils/debug.c
+++ b/srcs/utils/debug.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/30 17:55:37 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/01 12:50:00 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/20 14:44:11 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,8 @@ void	print_line_and_word_start_array(char *line, int *word_start_array)
 
 void	print_tokens(t_token *tokens, t_list *vars_list[3])
 {
-	int	i;
+	int		i;
+	char	*expanded_str;
 
 	printf("[ tokens ]\n");
 	i = 0;
@@ -43,10 +44,12 @@ void	print_tokens(t_token *tokens, t_list *vars_list[3])
 	{
 		if (tokens[i].type == WORD)
 		{
-			if (expand_word_token(&tokens[i].str, vars_list) == E_SYSTEM)
+			if (expand_word_token(tokens[i].str, vars_list, 0, &expanded_str)
+				 == E_SYSTEM)
 				return ;
 		}
-		printf("%2d	type:%c, str:%s,\n", i, tokens[i].type, tokens[i].str);
+		printf("%2d	type:%c, str:%s,\n", i, tokens[i].type, expanded_str);
+		free(expanded_str);
 		i++;
 	}
 }

--- a/srcs/utils/error.c
+++ b/srcs/utils/error.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/09 10:48:30 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/18 17:23:36 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/23 17:55:11 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,11 +45,11 @@ void	write_err(
 	const char	usages[7][42] = {"", "cd: usage: cd [dir]\n"
 		, "pwd: usage: pwd\n", "export: usage: export [name[=value] ...]\n"
 		, "unset: usage: unset [name ...]\n", "env: usage: env\n", ""};
-	const char	err_msgs[20][36] = {"", "", "invalid option", " not set"
-		, "numeric argument required", "too many arguments"
-		, "not a valid identifier", "invalid option or argument"
-		, "syntax error near unexpected token ", "command not found"
-		, "ambiguous redirect"};
+	const char	err_msgs[20][36] = {"", "", "invalid option\n", " not set\n"
+		, "numeric argument required\n", "too many arguments\n"
+		, "not a valid identifier\n", "invalid option or argument\n"
+		, "syntax error near unexpected token ", "command not found\n"
+		, "ambiguous redirect\n"};
 
 	if (status != E_GETCWD)
 		write(2, "minishell: ", 11);
@@ -59,10 +59,9 @@ void	write_err(
 	if (is_errno == 0)
 		write(2, err_msgs[status], ft_strlen(err_msgs[status]));
 	else
-		write(2, strerror(errno), ft_strlen(strerror(errno)));
+		perror(NULL);
 	if (status == E_SYNTAX)
-		write(2, err_word, ft_strlen(err_word));
-	write(2, "\n", 1);
+		ft_putendl_fd(err_word, 2);
 	if (status == E_INVALID_OP)
 		write(2, usages[place - 1], ft_strlen(usages[place - 1]));
 }

--- a/srcs/utils/error.c
+++ b/srcs/utils/error.c
@@ -6,13 +6,13 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/09 10:48:30 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/10 15:28:08 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/18 17:23:36 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static void	write_word(char *word, t_status status)
+static void	write_word(char *err_word, t_status status)
 {
 	if (status == E_GETCWD)
 	{
@@ -20,25 +20,25 @@ static void	write_word(char *word, t_status status)
 		write(2, "getcwd: cannot access parent directories: ", 42);
 		return ;
 	}
-	if (word == NULL || status == E_SYNTAX)
+	if (err_word == NULL || status == E_SYNTAX)
 		return ;
 	if (status == E_INVALID_ID)
 	{
 		write(2, "`", 1);
-		write(2, word, ft_strlen(word));
+		write(2, err_word, ft_strlen(err_word));
 		write(2, "'", 1);
 	}
 	else if (status == E_INVALID_OP)
-		write(2, word, 2);
+		write(2, err_word, 2);
 	else
-		write(2, word, ft_strlen(word));
+		write(2, err_word, ft_strlen(err_word));
 	if (status == E_NOSET_VAR)
 		return ;
 	write(2, ": ", 2);
 }
 
 void	write_err(
-	char *word, t_status status, t_bool is_errno, t_place place)
+	char *err_word, t_status status, t_bool is_errno, t_place place)
 {
 	const char	commands[8][13] = {"shell-init: "
 		, "echo: ", "cd: ", "pwd: ", "export: ", "unset: ", "env: ", "exit: "};
@@ -55,13 +55,13 @@ void	write_err(
 		write(2, "minishell: ", 11);
 	if (place != P_SHELL || status == E_GETCWD)
 		write(2, commands[place], ft_strlen(commands[place]));
-	write_word(word, status);
+	write_word(err_word, status);
 	if (is_errno == 0)
 		write(2, err_msgs[status], ft_strlen(err_msgs[status]));
 	else
 		write(2, strerror(errno), ft_strlen(strerror(errno)));
 	if (status == E_SYNTAX)
-		write(2, word, ft_strlen(word));
+		write(2, err_word, ft_strlen(err_word));
 	write(2, "\n", 1);
 	if (status == E_INVALID_OP)
 		write(2, usages[place - 1], ft_strlen(usages[place - 1]));
@@ -80,12 +80,11 @@ static int	get_value_from_status_table(int key, const int status_table[2][2])
 }
 
 t_exit_status	get_exit_status_with_errout(
-	char *word, t_status status, t_place place)
+	char *err_word, t_status status, t_place place)
 {
 	t_exit_status	exit_status;
 	const t_bool	is_errno = (
-		status == E_SYSTEM || status == E_OPEN || status == E_GETCWD
-		|| status == E_CHDIR);
+		status == E_SYSTEM || status == E_OPEN || status == E_GETCWD);
 	const int		status_table[8][3][2] = {
 		{{E_AMBIGUOUS, 1}, {E_NOCOMMAND, 127}, {E_SYNTAX, 258}}
 		, {}
@@ -96,7 +95,7 @@ t_exit_status	get_exit_status_with_errout(
 		, {{E_INVALID_OP_ARG, 1}}
 		, {{E_TOO_MANY_ARG, 1}, {E_NUM_ARG_REQ, 255}}};
 
-	write_err(word, status, is_errno, place);
+	write_err(err_word, status, is_errno, place);
 	// if (is_errno == 1 && place == P_SHELL)
 	// 	exit_status = errno;
 	if (is_errno == 1)
@@ -107,11 +106,12 @@ t_exit_status	get_exit_status_with_errout(
 	return (exit_status);
 }
 
-void	set_exit_status_with_errout(
-	char *word, t_status status, t_place place, t_list *vars_list[3])
+t_status	set_exit_status_with_errout(
+	char *err_word, t_status status, t_list *vars_list[3])
 {
 	t_exit_status	exit_status;
 
-	exit_status = get_exit_status_with_errout(word, status, place);
+	exit_status = get_exit_status_with_errout(err_word, status, P_SHELL);
 	set_exit_status(vars_list[SPECIAL], exit_status);
+	return (SUCCESS);
 }

--- a/srcs/utils/free.c
+++ b/srcs/utils/free.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/29 18:28:52 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/02 17:17:41 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/17 14:07:50 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,9 +52,11 @@ void	free_and_fill_null(char **p)
 	*p = NULL;
 }
 
-void	clear_vars_list(t_list *vars_list[3])
+void	clear_shell_data(t_data *d)
 {
-	ft_lstclear(&vars_list[ENV], free);
-	ft_lstclear(&vars_list[SHELL], free);
-	ft_lstclear(&vars_list[SPECIAL], free);
+	free(d->pwd);
+	ft_lstclear(&d->pid_list, free);
+	ft_lstclear(&d->vars_list[ENV], free);
+	ft_lstclear(&d->vars_list[SHELL], free);
+	ft_lstclear(&d->vars_list[SPECIAL], free);
 }

--- a/srcs/utils/free.c
+++ b/srcs/utils/free.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/29 18:28:52 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/17 14:07:50 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/19 17:41:06 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,12 +44,6 @@ t_status	free_and_return(void *p, t_status status)
 {
 	free(p);
 	return (status);
-}
-
-void	free_and_fill_null(char **p)
-{
-	free(*p);
-	*p = NULL;
 }
 
 void	clear_shell_data(t_data *d)

--- a/srcs/utils/free.c
+++ b/srcs/utils/free.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/29 18:28:52 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/19 17:41:06 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/22 10:56:21 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,6 +44,12 @@ t_status	free_and_return(void *p, t_status status)
 {
 	free(p);
 	return (status);
+}
+
+void	safe_free(void **p)
+{
+	free(*p);
+	*p = NULL;
 }
 
 void	clear_shell_data(t_data *d)

--- a/srcs/utils/utils.c
+++ b/srcs/utils/utils.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/04 10:45:21 by keguchi           #+#    #+#             */
-/*   Updated: 2021/08/16 12:02:45 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/17 16:01:49 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,9 +23,10 @@ char	*strjoin_with_null_support(char *s1, char *s2)
 	return (ft_strjoin(s1, s2));
 }
 
-t_bool	is_redirect_token(t_token_type type)
+t_bool	is_redirect_token(t_token token)
 {
-	if (type == GREATER || type == D_GREATER || type == LESS || type == D_LESS)
+	if (token.type == GREATER || token.type == D_GREATER
+		|| token.type == LESS || token.type == D_LESS)
 		return (1);
 	else
 		return (0);

--- a/srcs/utils/utils.c
+++ b/srcs/utils/utils.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/04 10:45:21 by keguchi           #+#    #+#             */
-/*   Updated: 2021/08/11 18:57:21 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/16 12:02:45 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,59 +21,6 @@ char	*strjoin_with_null_support(char *s1, char *s2)
 	else if (s2 == NULL)
 		return (ft_strdup(s1));
 	return (ft_strjoin(s1, s2));
-}
-
-char	*create_full_path(char *path, char *last_file)
-{
-	int		path_len;
-	char	*full_path;
-	char	*tmp;
-
-	if (path == NULL)
-		return (ft_strdup(last_file));
-	else if (last_file == NULL)
-		return (ft_strdup(path));
-	path_len = ft_strlen(path);
-	if (path[path_len - 1] == '/')
-		return (ft_strjoin(path, last_file));
-	full_path = ft_strjoin(path, "/");
-	if (full_path == NULL)
-		return (NULL);
-	tmp = full_path;
-	full_path = ft_strjoin(tmp, last_file);
-	free(tmp);
-	if (full_path == NULL)
-		return (NULL);
-	return (full_path);
-}
-
-t_status	search_match_path_from_path_var(char *last_file
-	, char *path_value, t_file_check_func check_func, char **matched_path)
-{
-	char	**paths;
-	char	*full_path;
-	int		i;
-
-	paths = ft_split(path_value, ':');
-	if (paths == NULL)
-		return (E_SYSTEM);
-	i = -1;
-	*matched_path = NULL;
-	while (*matched_path == NULL && paths[++i] != NULL)
-	{
-		full_path = create_full_path(paths[i], last_file);
-		if (full_path == NULL)
-		{
-			free_double_pointer((void **)paths);
-			return (E_SYSTEM);
-		}
-		if (check_func(full_path) == 1)
-			*matched_path = full_path;
-		else
-			free(full_path);
-	}
-	free_double_pointer((void **)paths);
-	return (SUCCESS);
 }
 
 t_bool	is_redirect_token(t_token_type type)


### PR DESCRIPTION
@keguchi-42 

変更点
- utils.c の関数2つをmini_cd.c に移動。(utilsにしては、内容が濃いと思ったため。)
- mini_exit.c
  　- 引数なしのときは現在のexit_statusを返す。
  　- LLONG の範囲外のときは、数字ではないときのエラー
- add_to_pid_list のdigit_numを削除
- clear_vars_list 関数を削除して、clear_shell_data 関数を追加。
- ctrl +c ,d, \ のときのprintf を削除 
- ctrl + cのときは、exit_status を1にする。
 　 event_hookの関数内でset_exit_status を実行できなかったため、一度readline関数から抜けて処理を行なった。
- start_process 関数に、signal関数を追加。
　  SIG_IGN はexecveを実行しても、デフォルトの動作にならないので、デフォルトの動作に戻す。
     https://linuxjm.osdn.jp/html/LDP_man-pages/man7/signal.7.html
- set_exit_status_with_errout 関数の返り値を変更。
- E_CHDIRは、E_SYSTEMで代用できたので、削除
----------------------------------------------------------------------------
@keguchi-42 追加です。

- start_process.c にヒアドキュメントの読み取り関数を追加。(2関数でいけました)
- expand_word にバグがあったのと、ヒアドキュメントのexpandはクォーテーションは削除せず、変数展開は行うので、それに対応しました。

それに伴い、以下expandに関して、共有事項です。
- 変数展開は、$に続く文字列が、変数として存在しうるものであれば、展開する。
　変数として存在しうるかどうかは、mini_export.cの check_valid_identifier 関数を参考にしてください。
- expand_word_token関数の使い方を変えました。
  t_status expand_word_token(char *word, t_list *vars_list[3], t_bool is_document, char **expanded_str)
　tokens[i].str に入れ替えておくのではなくて、参照渡しをして、展開した文字列を取得するようにしました。
- heredocument をexpandしても、NULLは返さないです。
    存在しない変数のみの入力の場合、改行のみになる。
    何も入力しない場合、空文字になる。