### PR TITLE
Read heredoc

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/28 09:39:27 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/26 11:42:38 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/28 12:09:13 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,6 +31,12 @@ typedef enum e_bool
 	FALSE		= 0,
 	TRUE		= 1
 }			t_bool;
+
+typedef enum e_expand_flag
+{
+	EXPAND_QUOTE	= 0x00000001,
+	EXPAND_VAR		= 0x00000002
+}			t_expand_flag;
 
 typedef enum e_str_type{
 	RAW			= 'R',
@@ -75,12 +81,14 @@ typedef enum e_vars_type{
 }			t_vars_type;
 
 typedef enum e_token_type{
-	PIPE		= '|',
-	GREATER		= '>',
-	LESS		= '<',
-	D_GREATER	= 'G',
-	D_LESS		= 'L',
-	WORD		= 'W'
+	PIPE			= '|',
+	GREATER			= '>',
+	LESS			= '<',
+	D_GREATER		= 'G',
+	D_LESS			= 'L',
+	WORD			= 'W',
+	HEREDOC_D_QUOTE	= '\"',
+	HEREDOC_S_QUOTE = '\''
 }			t_token_type;
 
 typedef struct s_token
@@ -111,7 +119,7 @@ t_status		process_command(t_data *d, t_token *tokens, int start, int end);
 t_status		process_redirect(t_token *tokens,
 					int i, t_list **save_fd, t_list *vars_list[3]);
 t_status		expand_word_token(char *word, t_list *vars_list[3],
-					t_bool is_heredoc, char **expanded_str);
+					t_expand_flag flag, char **expanded_str);
 
 // builtins
 t_exit_status	mini_echo(t_data *d, char **argv);
@@ -140,6 +148,8 @@ t_status		add_new_var(t_list **any_list, char *var);
 // utils
 char			*strjoin_with_null_support(char *s1, char *s2);
 t_bool			is_redirect_token(t_token token);
+char			*strjoin_three(char *s1, char *s2, char *s3);
+t_bool			is_special_quote_char(char *word, int i, t_str_type type);
 t_status		strjoin_to_cmd_str(t_token *tokens,
 					int word_index, char **cmd_str, t_list *vars_list[3]);
 t_status		split_cmd_str(char *cmd_str, char ***command);

--- a/srcs/process_command_utils.c
+++ b/srcs/process_command_utils.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/08/01 13:09:34 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/20 17:26:52 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/27 18:04:57 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,8 +18,8 @@ t_status	strjoin_to_cmd_str(
 	char	*tmp;
 	char	*expanded_str;
 
-	if (expand_word_token(tokens[word_index].str, vars_list, 0, &expanded_str)
-		 == E_SYSTEM)
+	if (expand_word_token(tokens[word_index].str, vars_list,
+			EXPAND_VAR | EXPAND_QUOTE, &expanded_str) == E_SYSTEM)
 		return (E_SYSTEM);
 	if (expanded_str == NULL)
 		return (SUCCESS);

--- a/srcs/utils/debug.c
+++ b/srcs/utils/debug.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/30 17:55:37 by mkamei            #+#    #+#             */
-/*   Updated: 2021/08/23 17:31:30 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/27 15:37:01 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,8 +44,8 @@ void	print_tokens(t_token *tokens, t_list *vars_list[3])
 	{
 		if (tokens[i].type == WORD)
 		{
-			if (expand_word_token(tokens[i].str, vars_list, 0, &expanded_str)
-				 == E_SYSTEM)
+			if (expand_word_token(tokens[i].str, vars_list,
+					EXPAND_VAR | EXPAND_QUOTE, &expanded_str) == E_SYSTEM)
 				return ;
 			printf("%2d	type:%c, str:%s,\n", i, tokens[i].type, expanded_str);
 			free(expanded_str);

--- a/srcs/utils/utils.c
+++ b/srcs/utils/utils.c
@@ -6,7 +6,7 @@
 /*   By: mkamei <mkamei@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/04 10:45:21 by keguchi           #+#    #+#             */
-/*   Updated: 2021/08/17 16:01:49 by mkamei           ###   ########.fr       */
+/*   Updated: 2021/08/27 16:41:12 by mkamei           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,4 +30,20 @@ t_bool	is_redirect_token(t_token token)
 		return (1);
 	else
 		return (0);
+}
+
+char	*strjoin_three(char *s1, char *s2, char *s3)
+{
+	char	*joined_str;
+	char	*tmp;
+
+	joined_str = ft_strjoin(s1, s2);
+	if (joined_str == NULL)
+		return (NULL);
+	tmp = joined_str;
+	joined_str = ft_strjoin(tmp, s3);
+	free(tmp);
+	if (joined_str == NULL)
+		return (NULL);
+	return (joined_str);
 }


### PR DESCRIPTION
@keguchi-42 

変更点
- expand_word_token関数の引数にexpand_flagを追加しました。
   quoteの削除と変数展開を行うかどうか、を自由に変更できます。
- tokenのタイプに、HEREDOC_D_QUOTEとHEREDOC_S_QUOTE を追加しました。
  HEREDOC_D_QUOTEの場合、heredocumentは""で囲まれた文字列のように扱う。つまりquoteを削除せず、変数展開する。
  HEREDOC_S_QUOTEの場合、heredocumentは''で囲まれた文字列のように扱う。つまりquoteを削除せず、変数展開もしない。
- ヒアドキュメントの読み取りの際に、tokenのタイプを変更するようにした。

process_redirect.c でのexpand
```
	flag = 0;
	if (tokens[i + 1].type == WORD)
		flag = EXPAND_QUOTE | EXPAND_VAR;
	else if (tokens[i + 1].type == HEREDOC_D_QUOTE)
		flag = EXPAND_VAR;
	if (expand_word_token(
			tokens[i + 1].str,vars_list, flag, &expanded_str) == E_SYSTEM)
		return (E_SYSTEM);
```
こんな感じで実行すれば大丈夫だと思います！！